### PR TITLE
feat: redesign hex sticker as SVG with speech-bubble motif

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <p align="center">
-  <img src="man/figures/hex-polyglotr.png" alt="polyglotr" height="200">
+  <img src="man/figures/hex-polyglotr.svg" alt="polyglotr" height="200">
 </p>
 <h1 align="center">polyglotr</h1>
 <p align="center">

--- a/helperfunctions/hexsticker-env.yml
+++ b/helperfunctions/hexsticker-env.yml
@@ -1,0 +1,57 @@
+name: polyglotr-hexsticker
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  # R runtime
+  - r-base>=4.3
+
+  # System libraries needed by magick / rsvg (conda-forge builds them reliably)
+  - imagemagick>=7
+  - librsvg>=2.56
+
+  # R packages available on conda-forge
+  - r-magick          # image I/O + SVG → PNG via ImageMagick
+  - r-rsvg            # librsvg bindings (fast SVG rasterisation)
+  - r-showtext        # custom web fonts in R graphics
+  - r-sysfonts        # dependency of showtext; Google Fonts download
+  - r-ggplot2         # plotting (hexSticker subplot alternative)
+  - r-png             # PNG read/write
+
+  # hexSticker is on CRAN but not always on conda-forge builds;
+  # install from R after activating this env:
+  #   Rscript -e "install.packages('hexSticker')"
+  - r-remotes         # in case you prefer remotes::install_cran("hexSticker")
+
+# ---------------------------------------------------------------------------
+# Usage:
+#
+#   1. Create env:
+#        micromamba env create -f helperfunctions/hexsticker-env.yml
+#        micromamba activate polyglotr-hexsticker
+#
+#   2. Install hexSticker from CRAN (not on conda-forge):
+#        Rscript -e "install.packages('hexSticker')"
+#
+#   3. Install Noto fonts for rsvg/PNG export of non-Latin script characters:
+#        mkdir -p ~/.local/share/fonts
+#        # CJK (Chinese + Japanese)
+#        curl -L "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf" \
+#             -o ~/.local/share/fonts/NotoSansCJKsc-Regular.otf
+#        # Arabic
+#        curl -L "https://github.com/googlefonts/noto-fonts/raw/main/hinted/ttf/NotoNaskhArabic/NotoNaskhArabic-Regular.ttf" \
+#             -o ~/.local/share/fonts/NotoNaskhArabic-Regular.ttf
+#        # Devanagari
+#        curl -L "https://github.com/googlefonts/noto-fonts/raw/main/hinted/ttf/NotoSerifDevanagari/NotoSerifDevanagari-Regular.ttf" \
+#             -o ~/.local/share/fonts/NotoSerifDevanagari-Regular.ttf
+#        fc-cache -f ~/.local/share/fonts/
+#
+#      Note: in browsers the SVG @import block loads these fonts from Google Fonts
+#      automatically — the manual install is only needed for rsvg/magick PNG export.
+#
+#   4. Generate the sticker:
+#        Rscript helperfunctions/make_hex_sticker.R
+#
+# To remove the env afterwards:
+#   micromamba env remove -n polyglotr-hexsticker
+# ---------------------------------------------------------------------------

--- a/helperfunctions/make_hex_sticker.R
+++ b/helperfunctions/make_hex_sticker.R
@@ -1,0 +1,63 @@
+# Generate the polyglotr hex sticker via the hexSticker R package.
+#
+# Prerequisites (install once or use the micromamba env in hexsticker-env.yml):
+#   install.packages(c("hexSticker", "showtext", "sysfonts", "magick", "rsvg"))
+#
+# Run from the package root:
+#   Rscript helperfunctions/make_hex_sticker.R
+
+library(hexSticker)
+library(showtext)
+library(sysfonts)
+library(magick)  # for SVG → raster conversion
+
+# ---------------------------------------------------------------------------
+# 1. Font setup
+# ---------------------------------------------------------------------------
+# Pull a clean, legible web font; works offline after first download.
+font_add_google("Nunito", "nunito")
+showtext_auto()
+
+# ---------------------------------------------------------------------------
+# 2. Convert the inner SVG to a raster image that hexSticker can render
+#    (hexSticker < 0.5 does not support SVG subplots natively).
+# ---------------------------------------------------------------------------
+inner_svg  <- "man/figures/polyglotr-logo-inner.svg"
+inner_png  <- tempfile(fileext = ".png")
+
+magick::image_read_svg(inner_svg, width = 600, height = 600) |>
+  magick::image_write(inner_png, format = "png")
+
+# ---------------------------------------------------------------------------
+# 3. Build the hex sticker
+# ---------------------------------------------------------------------------
+sticker(
+  # --- inner image ---
+  subplot  = inner_png,
+  s_x      = 1,        # horizontal centre of subplot (1 = hex centre)
+  s_y      = 1.22,     # vertical position (>1 = higher)
+  s_width  = 0.72,     # fraction of hex width
+  s_height = 0.72,
+
+  # --- package name ---
+  package   = "polyglotr",
+  p_size    = 18,
+  p_x       = 1,
+  p_y       = 0.52,    # lower portion of hex
+  p_color   = "#ffffff",
+  p_family  = "nunito",
+  p_fontface = "bold",
+
+  # --- hex styling ---
+  h_fill  = "#03045e",
+  h_color = "#caf0f8",
+  h_size  = 1.2,
+
+  # --- output ---
+  filename = "man/figures/hex-polyglotr-new.png",
+  dpi      = 600,
+  asp      = 0.857    # width / height ratio of a pointy-top hex sticker
+)
+
+message("Hex sticker written to man/figures/hex-polyglotr-new.png")
+message("Preview with: magick::image_read('man/figures/hex-polyglotr-new.png')")

--- a/man/figures/hex-polyglotr.svg
+++ b/man/figures/hex-polyglotr.svg
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  polyglotr hex sticker — speech-bubble redesign
+  Canvas 200 × 231  (R hex sticker ratio, pointy-top)
+  Hex vertices: (100,4) (196,60) (196,171) (100,227) (4,171) (4,60)
+
+  Four speech bubbles orbit a faint globe watermark.
+  Each bubble tail points toward the globe centre (100, 107).
+  Bubbles are slightly rotated for a playful feel.
+
+  Browser rendering: Google Fonts loaded via @import.
+  PNG export (rsvg/magick): install Noto fonts first — see hexsticker-env.yml.
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="200" height="231" viewBox="0 0 200 231">
+
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@700&amp;family=Noto+Serif+SC&amp;family=Noto+Serif+JP&amp;family=Noto+Naskh+Arabic&amp;display=swap');
+    </style>
+
+    <linearGradient id="bg" x1="10%" y1="0%" x2="90%" y2="100%">
+      <stop offset="0%"   stop-color="#03045e"/>
+      <stop offset="100%" stop-color="#0077b6"/>
+    </linearGradient>
+
+    <clipPath id="hexClip">
+      <polygon points="100,4 196,60 196,171 100,227 4,171 4,60"/>
+    </clipPath>
+
+    <!-- Border glow -->
+    <filter id="borderGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="2.2" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Floating bubble shadow -->
+    <filter id="bubbleShadow" x="-30%" y="-30%" width="160%" height="160%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3"
+        flood-color="#010d24" flood-opacity="0.55"/>
+    </filter>
+  </defs>
+
+  <!-- ── Background ─────────────────────────────────────────────────────── -->
+  <polygon
+    points="100,4 196,60 196,171 100,227 4,171 4,60"
+    fill="url(#bg)"/>
+
+  <!-- ── Globe watermark (opacity 0.17, clipped to hex) ────────────────── -->
+  <g opacity="0.17" clip-path="url(#hexClip)">
+    <circle cx="100" cy="107" r="46"
+      fill="none" stroke="#90e0ef" stroke-width="2.2"/>
+    <ellipse cx="100" cy="107" rx="46" ry="11"
+      fill="none" stroke="#90e0ef" stroke-width="1.5"/>
+    <ellipse cx="100" cy="84" rx="39" ry="9.5"
+      fill="none" stroke="#90e0ef" stroke-width="1"/>
+    <ellipse cx="100" cy="130" rx="39" ry="9.5"
+      fill="none" stroke="#90e0ef" stroke-width="1"/>
+    <ellipse cx="100" cy="107" rx="11" ry="46"
+      fill="none" stroke="#90e0ef" stroke-width="1.5"/>
+  </g>
+
+  <!--
+    ── Speech bubbles ───────────────────────────────────────────────────────
+    Each bubble is a <path> with rounded corners (Q beziers, r ≈ 11–12 px)
+    and a triangular tail pointing toward globe centre (100, 107).
+
+    Bubble 1 — Latin "A"
+      Bounds: (57,54)–(103,86)   centre (80, 70)
+      Tail: bottom edge, tip at (85, 103)
+
+    Bubble 2 — Chinese "文"
+      Bounds: (127,80)–(169,110)  centre (148, 95)
+      Tail: left side, tip at (113, 95)
+
+    Bubble 3 — Arabic "ع"
+      Bounds: (36,134)–(74,162)  centre (55, 148)
+      Tail: top edge (upper-right), tip at (89, 128)
+
+    Bubble 4 — Japanese "か"
+      Bounds: (127,138)–(165,166)  centre (146, 152)
+      Tail: top edge (upper-left), tip at (112, 128)
+  -->
+
+  <!-- Bubble 1: "A" — top-centre, -5° tilt -->
+  <g transform="rotate(-5, 80, 70)" filter="url(#bubbleShadow)">
+    <path
+      d="M 69,54 L 91,54
+         Q 103,54 103,66
+         L 103,74
+         Q 103,86 91,86
+         L 86,86 L 85,103 L 74,86
+         L 69,86
+         Q 57,86 57,74
+         L 57,66
+         Q 57,54 69,54 Z"
+      fill="white" stroke="#48cae4" stroke-width="1.8" stroke-linejoin="round"/>
+    <text x="80" y="71"
+      text-anchor="middle" dominant-baseline="central"
+      font-family="Georgia,'Times New Roman',serif"
+      font-size="20" font-weight="bold"
+      fill="#03045e">A</text>
+  </g>
+
+  <!-- Bubble 2: "文" — right side, +4° tilt -->
+  <g transform="rotate(4, 148, 95)" filter="url(#bubbleShadow)">
+    <path
+      d="M 138,80 L 158,80
+         Q 169,80 169,91
+         L 169,99
+         Q 169,110 158,110
+         L 138,110
+         Q 127,110 127,100
+         L 113,95 L 127,90
+         Q 127,80 138,80 Z"
+      fill="white" stroke="#48cae4" stroke-width="1.8" stroke-linejoin="round"/>
+    <text x="148" y="95"
+      text-anchor="middle" dominant-baseline="central"
+      font-family="'Noto Serif SC','Noto Serif CJK SC',serif"
+      font-size="18"
+      fill="#03045e">文</text>
+  </g>
+
+  <!-- Bubble 3: "ع" — bottom-left, -4° tilt -->
+  <g transform="rotate(-4, 55, 148)" filter="url(#bubbleShadow)">
+    <path
+      d="M 47,134
+         L 55,134 L 89,128 L 63,134
+         Q 74,134 74,145
+         L 74,151
+         Q 74,162 63,162
+         L 47,162
+         Q 36,162 36,151
+         L 36,145
+         Q 36,134 47,134 Z"
+      fill="white" stroke="#48cae4" stroke-width="1.8" stroke-linejoin="round"/>
+    <text x="55" y="148"
+      text-anchor="middle" dominant-baseline="central"
+      font-family="'Noto Naskh Arabic','Noto Sans Arabic',serif"
+      font-size="17"
+      fill="#03045e">ع</text>
+  </g>
+
+  <!-- Bubble 4: "か" — bottom-right, +5° tilt -->
+  <g transform="rotate(5, 146, 152)" filter="url(#bubbleShadow)">
+    <path
+      d="M 138,138
+         L 133,138 L 112,128 L 143,138
+         L 154,138
+         Q 165,138 165,149
+         L 165,155
+         Q 165,166 154,166
+         L 138,166
+         Q 127,166 127,155
+         L 127,149
+         Q 127,138 138,138 Z"
+      fill="white" stroke="#48cae4" stroke-width="1.8" stroke-linejoin="round"/>
+    <text x="146" y="152"
+      text-anchor="middle" dominant-baseline="central"
+      font-family="'Noto Serif JP','Noto Serif CJK JP',serif"
+      font-size="17"
+      fill="#03045e">か</text>
+  </g>
+
+  <!-- ── Package name ──────────────────────────────────────────────────── -->
+  <!--
+    At y=184 the hex half-width ≈ 174 px; "polyglotr" at 21 px ≈ 118 px wide.
+  -->
+  <text x="100" y="184"
+    text-anchor="middle" dominant-baseline="central"
+    font-family="Nunito,'Helvetica Neue',Arial,sans-serif"
+    font-size="21" font-weight="700" letter-spacing="0.6"
+    fill="#ffffff">polyglotr</text>
+
+  <!-- ── Hex border: white outer halo + cyan inner accent ──────────────── -->
+  <polygon
+    points="100,4 196,60 196,171 100,227 4,171 4,60"
+    fill="none" stroke="#ffffff" stroke-width="10"
+    stroke-linejoin="round" filter="url(#borderGlow)"/>
+  <polygon
+    points="100,4 196,60 196,171 100,227 4,171 4,60"
+    fill="none" stroke="#00b4d8" stroke-width="4"
+    stroke-linejoin="round"/>
+
+</svg>

--- a/man/figures/polyglotr-logo-inner.svg
+++ b/man/figures/polyglotr-logo-inner.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  polyglotr inner logo — transparent background for use as hexSticker subplot.
+  Canvas 200 × 200.  Four speech bubbles around a faint globe watermark.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Noto+Serif+SC&amp;family=Noto+Serif+JP&amp;family=Noto+Naskh+Arabic&amp;display=swap');
+    </style>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5"
+        flood-color="#010d24" flood-opacity="0.4"/>
+    </filter>
+  </defs>
+
+  <!-- Globe watermark (opacity 0.2, transparent bg) -->
+  <g opacity="0.20">
+    <circle cx="100" cy="100" r="42"
+      fill="none" stroke="#90e0ef" stroke-width="2"/>
+    <ellipse cx="100" cy="100" rx="42" ry="10"
+      fill="none" stroke="#90e0ef" stroke-width="1.4"/>
+    <ellipse cx="100" cy="79"  rx="35" ry="8.5"
+      fill="none" stroke="#90e0ef" stroke-width="0.9"/>
+    <ellipse cx="100" cy="121" rx="35" ry="8.5"
+      fill="none" stroke="#90e0ef" stroke-width="0.9"/>
+    <ellipse cx="100" cy="100" rx="10" ry="42"
+      fill="none" stroke="#90e0ef" stroke-width="1.4"/>
+  </g>
+
+  <!--
+    Bubble positions (centres, then bounding boxes):
+      "A"  → (80, 62)   bounds (55,47)–(105,77)
+      "文" → (145,88)  bounds (122,74)–(168,102)
+      "ع"  → (52,138)  bounds (30,124)–(74,152)
+      "か" → (147,141) bounds (125,127)–(169,155)
+  -->
+
+  <!-- Bubble 1: "A" — top, -5° tilt -->
+  <g transform="rotate(-5, 80, 62)" filter="url(#shadow)">
+    <path
+      d="M 67,47 L 93,47
+         Q 105,47 105,59
+         L 105,65
+         Q 105,77 93,77
+         L 85,77 L 83,94 L 75,77
+         L 67,77
+         Q 55,77 55,65
+         L 55,59
+         Q 55,47 67,47 Z"
+      fill="white" stroke="#48cae4" stroke-width="1.7" stroke-linejoin="round"/>
+    <text x="80" y="63"
+      text-anchor="middle" dominant-baseline="central"
+      font-family="Georgia,'Times New Roman',serif"
+      font-size="19" font-weight="bold" fill="#03045e">A</text>
+  </g>
+
+  <!-- Bubble 2: "文" — right, +4° tilt -->
+  <g transform="rotate(4, 145, 88)" filter="url(#shadow)">
+    <path
+      d="M 134,74 L 156,74
+         Q 168,74 168,86
+         L 168,90
+         Q 168,102 156,102
+         L 134,102
+         Q 122,102 122,92
+         L 108,88 L 122,84
+         Q 122,74 134,74 Z"
+      fill="white" stroke="#48cae4" stroke-width="1.7" stroke-linejoin="round"/>
+    <text x="145" y="88"
+      text-anchor="middle" dominant-baseline="central"
+      font-family="'Noto Serif SC','Noto Serif CJK SC',serif"
+      font-size="17" fill="#03045e">文</text>
+  </g>
+
+  <!-- Bubble 3: "ع" — bottom-left, -4° tilt -->
+  <g transform="rotate(-4, 52, 138)" filter="url(#shadow)">
+    <path
+      d="M 42,124
+         L 50,124 L 82,119 L 62,124
+         Q 74,124 74,136
+         L 74,140
+         Q 74,152 62,152
+         L 42,152
+         Q 30,152 30,140
+         L 30,136
+         Q 30,124 42,124 Z"
+      fill="white" stroke="#48cae4" stroke-width="1.7" stroke-linejoin="round"/>
+    <text x="52" y="138"
+      text-anchor="middle" dominant-baseline="central"
+      font-family="'Noto Naskh Arabic','Noto Sans Arabic',serif"
+      font-size="16" fill="#03045e">ع</text>
+  </g>
+
+  <!-- Bubble 4: "か" — bottom-right, +5° tilt -->
+  <g transform="rotate(5, 147, 141)" filter="url(#shadow)">
+    <path
+      d="M 137,127
+         L 130,127 L 111,118 L 143,127
+         L 157,127
+         Q 169,127 169,139
+         L 169,143
+         Q 169,155 157,155
+         L 137,155
+         Q 125,155 125,143
+         L 125,139
+         Q 125,127 137,127 Z"
+      fill="white" stroke="#48cae4" stroke-width="1.7" stroke-linejoin="round"/>
+    <text x="147" y="141"
+      text-anchor="middle" dominant-baseline="central"
+      font-family="'Noto Serif JP','Noto Serif CJK JP',serif"
+      font-size="16" fill="#03045e">か</text>
+  </g>
+
+</svg>


### PR DESCRIPTION
## Summary

- Replaces the raster PNG globe with a fully **vector SVG** hex sticker — crisp at any size
- Four **speech bubbles** (Latin **A**, Chinese **文**, Arabic **ع**, Japanese **か**) orbit a faint globe watermark, each slightly rotated for a playful feel; tails converge on the globe centre
- Dark navy → ocean-blue gradient background with white+cyan double border

## New files

| File | Purpose |
|---|---|
| `man/figures/hex-polyglotr.svg` | Standalone hex sticker (drop-in for the PNG) |
| `man/figures/polyglotr-logo-inner.svg` | Inner logo for use as `hexSticker::sticker()` subplot |
| `helperfunctions/make_hex_sticker.R` | Reproducible R script (hexSticker + magick + showtext) |
| `helperfunctions/hexsticker-env.yml` | micromamba env with all deps + Noto font install instructions |

## Fonts

- **Browsers** (GitHub README, pkgdown): `@import` loads Noto fonts from Google Fonts automatically
- **PNG export** (rsvg / magick): install Noto fonts locally — exact `curl` commands in `hexsticker-env.yml`

## Test plan

- [ ] Open `man/figures/hex-polyglotr.svg` in a browser — verify all four script characters render correctly
- [ ] Optionally run `Rscript helperfunctions/make_hex_sticker.R` after setting up the micromamba env
- [ ] Update README `<img>` src to `.svg` if replacing the PNG reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)